### PR TITLE
Fix up web.xml config (issue #36)

### DIFF
--- a/WebContent/WEB-INF/web.xml
+++ b/WebContent/WEB-INF/web.xml
@@ -6,38 +6,6 @@
     <welcome-file>index.htm</welcome-file>
     <welcome-file>index.jsp</welcome-file>
   </welcome-file-list>
-  <servlet>
-    <servlet-name>AjaxServlet</servlet-name>
-    <servlet-class>net.socialgamer.cah.servlets.AjaxServlet</servlet-class>
-  </servlet>
-  <servlet>
-    <servlet-name>JavascriptConfigServlet</servlet-name>
-    <servlet-class>net.socialgamer.cah.servlets.JavascriptConfigServlet</servlet-class>
-  </servlet>
-  <servlet>
-    <servlet-name>LongPollServlet</servlet-name>
-    <servlet-class>net.socialgamer.cah.servlets.LongPollServlet</servlet-class>
-  </servlet>
-  <servlet>
-    <servlet-name>Schema</servlet-name>
-    <servlet-class>net.socialgamer.cah.servlets.Schema</servlet-class>
-  </servlet>
-  <servlet-mapping>
-    <servlet-name>AjaxServlet</servlet-name>
-    <url-pattern>/AjaxServlet</url-pattern>
-  </servlet-mapping>
-  <servlet-mapping>
-    <servlet-name>JavascriptConfigServlet</servlet-name>
-    <url-pattern>/js/cah.config.js</url-pattern>
-  </servlet-mapping>
-  <servlet-mapping>
-    <servlet-name>LongPollServlet</servlet-name>
-    <url-pattern>/LongPollServlet</url-pattern>
-  </servlet-mapping>
-  <servlet-mapping>
-    <servlet-name>Schema</servlet-name>
-    <url-pattern>/Schema</url-pattern>
-  </servlet-mapping>
   <listener>
     <listener-class>net.socialgamer.cah.StartupUtils</listener-class>
   </listener>

--- a/src/net/socialgamer/cah/servlets/JavascriptConfigServlet.java
+++ b/src/net/socialgamer/cah/servlets/JavascriptConfigServlet.java
@@ -5,11 +5,13 @@ import java.io.PrintWriter;
 
 import javax.servlet.ServletConfig;
 import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 
+@WebServlet("/js/cah.config.js")
 public class JavascriptConfigServlet extends HttpServlet {
 
   private static final long serialVersionUID = 4287566906479434127L;


### PR DESCRIPTION
Add missing WebServlet annotation to JavascriptConfigServlet class, for
consistency.
Remove redundant configuration items from web.xml, as on Tomcat 7 with
default settings these cause the following error:
java.lang.IllegalArgumentException: The servlets named
[JavascriptConfigServlet] and
[net.socialgamer.cah.servlets.JavascriptConfigServlet] are both mapped
to the url-pattern [/js/cah.config.js] which is not permitted
