### PR TITLE
Hide "you are the czar" filter in the lobby

### DIFF
--- a/WebContent/js/cah.game.js
+++ b/WebContent/js/cah.game.js
@@ -1173,6 +1173,7 @@ cah.Game.prototype.stateChange = function(data) {
       }
       this.roundCards_ = {};
       $(".game_white_cards", this.element_).empty();
+      $(".game_hand_filter", this.element_).addClass("hide");		// in case they were the judge last round
 
       this.showOptions_();
 


### PR DESCRIPTION
When the game resets to the lobby, whoever was Czar last can still see the "You are the Card Czar" filter covering where their hand used to be.  Normally this isn't a big deal but when it affects the game host it makes it harder to see and/or change the options.

This change forces the banner to be hidden when the game returns to the lobby state.
