### PR TITLE
Add option to disable card animation

### DIFF
--- a/WebContent/cah.css
+++ b/WebContent/cah.css
@@ -579,6 +579,19 @@ span.debug, span.admin {
   font-weight:700;
 }
 
+.checkbox {
+  margin-right: 4px;
+  white-space: nowrap;
+}
+
+.checkbox input {
+  vertical-align: middle;
+}
+
+.checkbox span {
+  vertical-align: middle;
+}
+
 .nowrap {
   white-space: nowrap;
 }

--- a/WebContent/game.jsp
+++ b/WebContent/game.jsp
@@ -262,6 +262,7 @@ HttpSession hSession = request.getSession(true);
       <input type="button" class="game_show_last_round game_menu_bar" value="Show Last Round"
           disabled="disabled" />
       <input type="button" class="game_show_options game_menu_bar" value="Hide Game Options" />
+      <label class="game_menu_bar checkbox"><input type="checkbox" class="game_animate_cards" checked="checked" /><span> Animate Cards</span></label>
       <div class="game_message" role="status">
         Waiting for server...
       </div>

--- a/WebContent/js/cah.game.js
+++ b/WebContent/js/cah.game.js
@@ -534,6 +534,7 @@ cah.Game.prototype.addRoundWhiteCard_ = function(cards) {
  * @private
  */
 cah.Game.prototype.handCardMouseEnter_ = function(e) {
+  if (!$(".game_animate_cards", this.element_).attr("checked")) return;
   $(e.data.card.getElement()).css("z-index", "2").animate({
     scale : this.handCardLargeScale_,
     width : this.handCardLargeSize_,
@@ -567,6 +568,7 @@ cah.Game.prototype.handCardMouseLeave_ = function(e) {
  * @private
  */
 cah.Game.prototype.roundCardMouseEnter_ = function(e) {
+  if (!$(".game_animate_cards", this.element_).attr("checked")) return;
   $(e.data.card.getElement()).css("z-index", "201").animate({
     scale : this.roundCardLargeScale_,
     width : this.roundCardLargeSize_,


### PR DESCRIPTION
With certain combinations of browser window sizes and number of players (and the base card size that this produces), the card growing animation that appears on mouseover may result in the last white card in the round bouncing down to the following line (and then bouncing back because now the mouse is no longer over it, and then bouncing back down, etc).  This can make it hard for the Czar to select the last card in the round as the winner.

This is not a perfect solution, but it works: a checkbox is added to the top of the screen, allowing any player to temporarily or permanently disable the card resizing animations.  The Czar could turn this off just while they're selecting the card, or some players may prefer to leave it off permanently if they just don't like the animation.

(Only the opening animation is disabled, to ensure that the closing animation runs to completion and the card returns to its base size even if the checkbox is toggled while the animation is playing.)
