### PR TITLE
Add /hand command to resync hand

### DIFF
--- a/WebContent/js/cah.app.js
+++ b/WebContent/js/cah.app.js
@@ -163,6 +163,17 @@ function chatsubmit_click(game_id, parent_element) {
         // this could also be an IP address
         ajax = cah.Ajax.build(cah.$.AjaxOperation.BAN).withNickname(text.split(' ')[0]);
         break;
+      case 'hand':
+    	if (game_id !== null) {
+    	  var game = cah.currentGames[game_id];
+    	  if (game) { 
+    		game.removeAllCards();
+    	  }
+    	  ajax = cah.Ajax.build(cah.$.AjaxOperation.GET_CARDS).withGameId(game_id);
+    	} else {
+    	  cah.log.error("This command only works in a game.");
+    	}
+    	break;
       case 'names':
         ajax = cah.Ajax.build(cah.$.AjaxOperation.NAMES);
         break;

--- a/WebContent/js/cah.game.js
+++ b/WebContent/js/cah.game.js
@@ -463,6 +463,24 @@ cah.Game.prototype.removeCardFromHand = function(card) {
 };
 
 /**
+ * Remove all cards from the screen.
+ */
+cah.Game.prototype.removeAllCards = function() {
+  var handCount = this.hand_.length;
+  for ( var i = 0; i < handCount; i++) {
+    this.removeCardFromHand(this.hand_[0]);
+  }
+  this.handSelectedCard_ = null;
+  $(".confirm_card", this.element_).attr("disabled", "disabled");
+  $(".game_black_card", this.element_).empty();
+  for ( var index in this.roundCards_) {
+    $(this.roundCards_[index]).off(".round");
+  }
+  this.roundCards_ = {};
+  $(".game_white_cards", this.element_).empty();
+};
+
+/**
  * Set the round white cards.
  * 
  * @param {Array}
@@ -1160,19 +1178,8 @@ cah.Game.prototype.stateChange = function(data) {
 
   switch (this.state_) {
     case cah.$.GameState.LOBBY:
-      var handCount = this.hand_.length;
-      for ( var i = 0; i < handCount; i++) {
-        this.removeCardFromHand(this.hand_[0]);
-      }
-      this.handSelectedCard_ = null;
+      this.removeAllCards();
       this.judge_ = null;
-      $(".confirm_card", this.element_).attr("disabled", "disabled");
-      $(".game_black_card", this.element_).empty();
-      for ( var index in this.roundCards_) {
-        $(this.roundCards_[index]).off(".round");
-      }
-      this.roundCards_ = {};
-      $(".game_white_cards", this.element_).empty();
 
       this.showOptions_();
 


### PR DESCRIPTION
In the event that a player's client gets out of sync with the server (particularly involving the cards in the hand or in play), this allows the player to enter "/hand" in game chat to re-fetch the correct cards.  (Note that despite the name it also affects played cards, not just the hand.  If you'd prefer a different command name to reflect this, that's fine.  One suggestion might be "/refresh" or "/cards".)

Intended for cases such as just after some other player has joined or left the game (since that tends to weird out the displayed cards), or if a client has missed some messages and the player ends up with too few or too many cards in their hand, or gets "you don't have that card" errors when they try to play.

This is a little redundant, as much the same effect can be achieved simply by refreshing the page.  However this seems like a tidier solution (and players can be reluctant to reload the page in case they lose their score or get kicked out of the game, even though normally that doesn't happen).  It's also friendlier to the server to just get a few Ajax calls instead of having to re-serve the entire HTML/CSS/JS bundle.

(It would be _slightly_ cleaner if it cleared away the previous cards only once the Ajax query returned, but the implementation as is allowed re-use of an existing handler rather than having to create a new one.  However it might be possible to move the clear operation to the common handler anyway -- I think the other case this is used it would still be safe.  I haven't made this change because I haven't tested that theory.)
