### PR TITLE
Add "score" command

### DIFF
--- a/WebContent/js/cah.ajax.handlers.js
+++ b/WebContent/js/cah.ajax.handlers.js
@@ -235,3 +235,14 @@ cah.ajax.SuccessHandlers[cah.$.AjaxOperation.KICK] = function(data) {
 cah.ajax.SuccessHandlers[cah.$.AjaxOperation.BAN] = function(data) {
   // pass
 };
+
+cah.ajax.SuccessHandlers[cah.$.AjaxOperation.SCORE] = function(data, req) {
+  var gameId = req[cah.$.AjaxRequest.GAME_ID];
+  var info = data[cah.$.AjaxResponse.PLAYER_INFO];
+  var msg = info[cah.$.GamePlayerInfo.NAME] + " has " + info[cah.$.GamePlayerInfo.SCORE] + " Awesome Points.";
+  if (gameId) {
+    cah.log.status_with_game(gameId, msg);
+  } else {
+    cah.log.status(msg);
+  }
+};

--- a/WebContent/js/cah.app.js
+++ b/WebContent/js/cah.app.js
@@ -163,6 +163,12 @@ function chatsubmit_click(game_id, parent_element) {
         // this could also be an IP address
         ajax = cah.Ajax.build(cah.$.AjaxOperation.BAN).withNickname(text.split(' ')[0]);
         break;
+      case 'score':
+    	ajax = cah.Ajax.build(cah.$.AjaxOperation.SCORE).withMessage(text);
+    	if (game_id != null) {
+    	  ajax = ajax.withGameId(game_id);
+    	}
+    	break;
       case 'names':
         ajax = cah.Ajax.build(cah.$.AjaxOperation.NAMES);
         break;

--- a/WebContent/js/cah.constants.js
+++ b/WebContent/js/cah.constants.js
@@ -11,6 +11,7 @@ cah.$.AjaxOperation.FIRST_LOAD = "fl";
 cah.$.AjaxOperation.LOG_OUT = "lo";
 cah.$.AjaxOperation.BAN = "b";
 cah.$.AjaxOperation.JUDGE_SELECT = "js";
+cah.$.AjaxOperation.SCORE = "SC";
 cah.$.AjaxOperation.GAME_LIST = "ggl";
 cah.$.AjaxOperation.CHANGE_GAME_OPTIONS = "cgo";
 cah.$.AjaxOperation.GET_GAME_INFO = "ggi";

--- a/src/net/socialgamer/cah/Constants.java
+++ b/src/net/socialgamer/cah/Constants.java
@@ -182,6 +182,7 @@ public class Constants {
     NAMES("gn"),
     PLAY_CARD("pc"),
     REGISTER("r"),
+    SCORE("SC"),
     START_GAME("sg");
 
     private final String op;

--- a/src/net/socialgamer/cah/data/Player.java
+++ b/src/net/socialgamer/cah/data/Player.java
@@ -73,6 +73,13 @@ public class Player {
   }
 
   /**
+   * Increase the player's score by the specified amount.
+   */
+  public void increaseScore(final int offset) {
+    score += offset;
+  }
+
+  /**
    * Reset the player's score to 0.
    */
   public void resetScore() {

--- a/src/net/socialgamer/cah/handlers/Handlers.java
+++ b/src/net/socialgamer/cah/handlers/Handlers.java
@@ -28,6 +28,7 @@ public class Handlers {
     LIST.put(NamesHandler.OP, NamesHandler.class);
     LIST.put(PlayCardHandler.OP, PlayCardHandler.class);
     LIST.put(RegisterHandler.OP, RegisterHandler.class);
+    LIST.put(ScoreHandler.OP, ScoreHandler.class);
     LIST.put(StartGameHandler.OP, StartGameHandler.class);
   }
 }

--- a/src/net/socialgamer/cah/handlers/ScoreHandler.java
+++ b/src/net/socialgamer/cah/handlers/ScoreHandler.java
@@ -1,0 +1,72 @@
+package net.socialgamer.cah.handlers;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.servlet.http.HttpSession;
+
+import net.socialgamer.cah.Constants.AjaxOperation;
+import net.socialgamer.cah.Constants.AjaxRequest;
+import net.socialgamer.cah.Constants.AjaxResponse;
+import net.socialgamer.cah.Constants.ErrorCode;
+import net.socialgamer.cah.Constants.ReturnableData;
+import net.socialgamer.cah.Constants.SessionAttribute;
+import net.socialgamer.cah.RequestWrapper;
+import net.socialgamer.cah.data.ConnectedUsers;
+import net.socialgamer.cah.data.Game;
+import net.socialgamer.cah.data.Player;
+import net.socialgamer.cah.data.User;
+
+import com.google.inject.Inject;
+
+
+public class ScoreHandler extends Handler {
+
+  public static final String OP = AjaxOperation.SCORE.toString();
+
+  private final ConnectedUsers connectedUsers;
+
+  @Inject
+  public ScoreHandler(final ConnectedUsers connectedUsers) {
+    this.connectedUsers = connectedUsers;
+  }
+
+  @Override
+  public Map<ReturnableData, Object> handle(final RequestWrapper request, final HttpSession session) {
+    final User user = (User) session.getAttribute(SessionAttribute.USER);
+    assert (user != null);
+    final String params = request.getParameter(AjaxRequest.MESSAGE);
+    final String[] args = (params == null || params.isEmpty()) ? new String[0] : params.trim()
+        .split(" ");
+
+    final User target = (args.length > 0) ? connectedUsers.getUser(args[0]) : user;
+    if (null == target) {
+      return error(ErrorCode.NO_SUCH_USER);
+    }
+    final Game game = target.getGame();
+    if (null == game) {
+      return error(ErrorCode.INVALID_GAME);
+    }
+    final Player player = game.getPlayerForUser(target);
+    if (null == player) {
+      return error(ErrorCode.INVALID_GAME);
+    }
+
+    final Map<ReturnableData, Object> data = new HashMap<ReturnableData, Object>();
+
+    if (user.isAdmin() && args.length == 2) {
+      // for now only admins can change scores.  could possibly extend this to let the host do it,
+      // provided it's for a player in the same game and it does a gamewide announcement.
+      try {
+        final int offset = Integer.parseInt(args[1]);
+        player.increaseScore(offset);
+        game.notifyPlayerInfoChange(player);
+      } catch (final NumberFormatException e) {
+        return error(ErrorCode.BAD_REQUEST);
+      }
+    }
+    data.put(AjaxResponse.PLAYER_INFO, game.getPlayerInfo(player));
+
+    return data;
+  }
+}


### PR DESCRIPTION
Can be used by any user to view the current score of any other user (even across games).  Also allows admins to modify a user's current score (up or down), which can be useful on private servers where admins are playing and can "repair" a score if someone gets disconnected or kicked accidentally.

Could possibly be extended in future to allow game hosts to modify scores of players in the same game, but this would require some thought to abuse prevention.  At least some kind of gamewide announcement.
