### PR TITLE
Don't reset game when kicking idle players

### DIFF
--- a/src/net/socialgamer/cah/data/Game.java
+++ b/src/net/socialgamer/cah/data/Game.java
@@ -880,14 +880,16 @@ public class Game {
     }
 
     synchronized (playedCards) {
-      // not sure how much of this check is actually required
-      if (players.size() < 3 || playedCards.size() < 2 || state != GameState.PLAYING) {
-        logger.info(String.format(
-            "Resetting game %d due to insufficient players after removing %d idle players.",
-            id, playersToRemove.size()));
-        resetState(true);
-      } else {
-        judgingState();
+      if (state == GameState.PLAYING || playersToRemove.size() == 0) {
+        // not sure how much of this check is actually required
+        if (players.size() < 3 || playedCards.size() < 2) {
+          logger.info(String.format(
+              "Resetting game %d due to insufficient players after removing %d idle players.",
+              id, playersToRemove.size()));
+          resetState(true);
+        } else {
+          judgingState();
+        }
       }
     }
 


### PR DESCRIPTION
Fixes #32.  Finally.  Hallelujah.

The problem was that when it actually removed players, the game had already been switched to JUDGING or ROUND_OVER state by removePlayer, which hit the wrong path in this check.

The new version is probably still a little more paranoid than it really needs to be, but it works.
