### PR TITLE
correctly render cardcast codes with leading zeros

### DIFF
--- a/WebContent/js/cah.game.js
+++ b/WebContent/js/cah.game.js
@@ -812,7 +812,7 @@ cah.Game.prototype.listCardcastDecks = function(cardSets) {
  * @private
  */
 cah.Game.prototype.displayCardcastDeckMessage_ = function(deckInfo, verb) {
-  var code = (-1 * deckInfo[cah.$.CardSetData.ID]).toString(36).toUpperCase();
+  var code = ("00000" + (-1 * deckInfo[cah.$.CardSetData.ID]).toString(36).toUpperCase()).slice(-5);
   var str = verb + ": Cardcast deck '" + deckInfo[cah.$.CardSetData.CARD_SET_NAME]
       + "' (code: <a target='_blank' href='http://www.cardcastgame.com/browse/deck/" + code + "'> "
       + code + "</a>), with " + deckInfo[cah.$.CardSetData.BLACK_CARDS_IN_DECK]


### PR DESCRIPTION
The /listcardcast output drops leading zeros from the deck codes, due to the string -> number -> string conversion process.

This commit fixes the displayed output by zero-padding the code to ensure it has the full five digits.

I don't know if this same issue manifests elsewhere.
