### PR TITLE
Adding Docker docs to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,11 @@ If you're doing ```mvn clean package war:exploded jetty:run```, you now need to 
 
 
 For GeoIP functions to work, download http://geolite.maxmind.com/download/geoip/database/GeoLite2-City.mmdb.gz somewhere, gunzip it, and update the geoip.db value in build.properties to point to it.
+
+## Third-Party Usage
+
+A Docker package for this project exists at [emcniece/DockerYourXyzzy](https://github.com/emcniece/DockerYourXyzzy):
+
+```sh
+docker run -d -p 8080:8080 emcniece/dockeryourxyzzy:dev
+```


### PR DESCRIPTION
Hello! I have Dockerized this project and wanted to share it. Feel free to merge or close this at your discretion.

This PR adds a link and some instructions to the README so that users can develop and play with this in a containerized environment.

Building and running this project is now possible with a single command:

```sh
# Build & run:
docker run -d --name pyx -p 8080:8080 emcniece/dockeryourxyzzy:dev

# Watch logs & wait for project to be ready:
docker logs -f pyx

# Visit http://localhost:8080 in browser
```

- Github: [emcniece/DockerYourXyzzy](https://github.com/emcniece/DockerYourXyzzy)
- Docker Hub: [emcniece/dockeryourxyzzy](https://hub.docker.com/r/emcniece/dockeryourxyzzy/)