### PR TITLE
Hibernate: avoid potential deadlock on c3p0

### DIFF
--- a/src/main/java/net/socialgamer/cah/handlers/StartGameHandler.java
+++ b/src/main/java/net/socialgamer/cah/handlers/StartGameHandler.java
@@ -80,7 +80,7 @@ public class StartGameHandler extends GameWithPlayerHandler {
         data.put(ErrorInformation.WHITE_CARDS_PRESENT, game.loadWhiteDeck(cardSets).totalCount());
         data.put(ErrorInformation.WHITE_CARDS_REQUIRED, game.getRequiredWhiteCardCount());
         return error(ErrorCode.NOT_ENOUGH_CARDS, data);
-      } else if (!game.start()) {
+      } else if (!game.start(hibernateSession)) {
         return error(ErrorCode.NOT_ENOUGH_PLAYERS);
       } else {
         return data;


### PR DESCRIPTION
If StartGameHandler takes the last connection available in the c3p0
pool, then Game.start() will block inside sessionProvider.get().  But
since this is nested within, StartGameHandler never gets to the
`finally` block where it releases its connection.

## Testing done

`mvn clean package war:war`, ran a local stress test and I am no longer seeing Tomcat HTTP threads stuck inside AjaxHandler.