### PR TITLE
update postgresql JDBC driver to latest version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -320,9 +320,9 @@
       <version>1.2.17</version>
     </dependency>
     <dependency>
-      <groupId>postgresql</groupId>
+      <groupId>org.postgresql</groupId>
       <artifactId>postgresql</artifactId>
-      <version>8.4-702.jdbc3</version>
+      <version>42.2.12</version>
     </dependency>
     <dependency>
       <groupId>org.easymock</groupId>


### PR DESCRIPTION
This fixes compatibility with newer versions of PostgreSQL.
At some point, they stopped tying JDBC driver releases to Postgres releases, so they bumped the version number up to 42. I don't know why either.